### PR TITLE
🔧 conditionally usage of static dir based on OS

### DIFF
--- a/apps/react-tailwind-components/.storybook/main.ts
+++ b/apps/react-tailwind-components/.storybook/main.ts
@@ -17,7 +17,7 @@ const config: StorybookConfig = {
   docs: {
     autodocs: 'tag',
   },
-  staticDirs: isWindows ? ['..\\public'] : ['../public'],
+  staticDirs: isWindows ? ['..\\public'] : ['../public'], //based on OS conditionally use static dirs for storybook
 }
 
 export default config


### PR DESCRIPTION
conditionally usage of static dirs based on the O.S. 
windows uses ` ['..\\public'] `
mac uses `['../public']`